### PR TITLE
Added two different pretrack plot options

### DIFF
--- a/PlotPretracking.m
+++ b/PlotPretracking.m
@@ -1,0 +1,94 @@
+function [] = PlotPretracking(data,b,tracks,FeatSize,NmPerPixel, ...
+                              FileStub,PlotOption)
+
+% PlotPretracking plots the imagedata, the bandpassed data together with
+% the results of the pretracking of the particles.
+%
+% INPUT:
+%     data: Collection of image frames.
+%     b: Collection of bandpassed image frames.
+%     tracks: The collection of particle tracks in the frames.
+%     FeatSize: Full optical diameter of particle (pixels).
+%     NmPerPixel: Actual pixel width (nm).
+%     FileStub: Path to the image_stack to be analyzed. 
+%     PlotOption: Option for what plotting function will be used.
+
+if strcmp(PlotOption,'simple')
+    PlotRawData(data,tracks,FeatSize,NmPerPixel,FileStub)
+    
+elseif strcmp(PlotOption,'bandpass')
+    PlotBandpassedData(data,b,tracks,FeatSize,NmPerPixel,FileStub)
+else
+    disp('Warning: PlotOpt in Pretrack not recognized.') 
+end  
+end
+
+function [] = PlotRawData(data,tracks,FeatSize,NmPerPixel,FileStub)
+% PLOTRAWDATA plots the rawdata together with the centroids and puts out 
+% frame to a movie file every 10 frames.
+
+fig1 = figure;
+whitebg(fig1);
+
+for frame = 1:size(data,3)
+    tempx = tracks(tracks(:,5)==frame,1);
+    tempy = tracks(tracks(:,5)==frame,2);
+    
+    hold off
+    imagesc(data(:,:,frame))
+    colormap gray
+    hold on
+    scatter(tempx,tempy,'r')
+    title(['\fontsize{16} Raw data [1 px =' num2str(NmPerPixel) ' nm]'])
+    xlabel('x-axis (pixels)')
+    ylabel('y-axis (pixels)')
+    truesize
+    if mod(frame,10) == 0
+        f = getframe;
+        imwrite(frame2im(f),[FileStub 'tracking_movie.tif'], ...
+                'tiff','compression','none','writemode','append');
+    end
+end
+close
+end  
+ 
+function [] = PlotBandpassedData(data,b,tracks,FeatSize,NmPerPixel,FileStub)
+% PLOTBANDPASSEDDATA plots the rawdata and the bandpassed data together 
+% with the centroids and the boundaries of the feature as defined.
+% The function puts out a frame to a movie file every 10 frames.
+
+fig1 = figure;
+whitebg(fig1);
+for frame = 1:size(data,3)   
+    tempx = tracks(tracks(:,5)==frame,1);
+    tempy = tracks(tracks(:,5)==frame,2);
+    hold off
+    ax1 = subplot(1,2,1);
+    h1 = imagesc(data(:,:,frame));
+    colormap gray
+    hold(ax1,'on')
+    h2 = scatter(ax1,tempx,tempy, 2*pi*(FeatSize/2)^2,'g');
+    hold(ax1,'on')
+    h3 = scatter(ax1,tempx,tempy,10,'r','filled');
+    title(ax1, ['\fontsize{16} Raw data [1 px =' num2str(NmPerPixel) ' nm]'])
+    xlabel(ax1, 'x-axis (pixels)')
+    ylabel(ax1, 'y-axis (pixels)')
+    ax2 = subplot(1,2,2); 
+    h4 = imagesc(b(:,:,frame));
+    colormap gray
+    hold(ax2,'on')        
+    h5 = scatter(ax2,tempx,tempy, 2*pi*(FeatSize/2)^2,'g');
+    hold(ax2,'on')
+    h6 = scatter(ax2,tempx,tempy,10,'r','filled');
+    title(ax2, ['\fontsize{16} Bandpassed data [1 px =' num2str(NmPerPixel) ' nm]'])
+    xlabel(ax2, 'x-axis (pixels)')
+    ylabel(ax2, 'y-axis (pixels)')   
+    truesize
+    if mod(frame,10) == 0
+        f = getframe(fig1);
+        imwrite(frame2im(f),[FileStub 'tracking_movie.tif'], ...
+                'tiff','compression','none','writemode','append');
+    end
+end
+close
+end

--- a/tracker_caller_4QM.m
+++ b/tracker_caller_4QM.m
@@ -28,7 +28,8 @@ function [] = tracker_caller_4QM(filestub,nframes, ...
 % PrintTrackProgress -- [optional] Turns on or off printing progress to screen.
 % maxdisp -- [optional] maxdisp should be set to a value somewhat less than 
 % the mean spacing between the particles.
- 
+% plotopt -- Options for plotting data ['simple','bandpassed',0] 
+%
 % NOTES
 %
 % The imwrite() function is unstable when windows file explorer is opened.
@@ -113,28 +114,17 @@ step_amplitude = 1;
     Ntracks = size(unique(tracks(:,6)));
     disp([char(9) 'Found a total of ' num2str(Ntracks(1)) ' tracks.'])
     clear cnt
-    
-    if plotopt
-        % Visually check tracks
-        disp([char(9) 'Visual check of tracks.'])
-                for frame = 1:size(data,3)
-    
-                    tempx = tracks(tracks(:,5)==frame,1);
-                    tempy = tracks(tracks(:,5)==frame,2);
-    
-                    hold off
-                    imagesc(data(:,:,frame))
-                    colormap gray
-                    hold on
-                    scatter(tempx,tempy,'r')
-                    truesize
-                    f = getframe;
-%                     imwrite(frame2im(f),[filestub 'tracking_movie.tif'], ...
-%                             'tiff','compression','none','writemode','append');
-    
-        end
-        close
-                
+
+    % Visually check tracks if desired.
+    switch plotopt
+        case 'simple'
+            disp([char(9) 'Visual check of tracks.'])
+            PlotPretracking(data,b,tracks,feat_size,nm_per_pixel,filestub,'simple')
+        case 'bandpass'
+            disp([char(9) 'Visual check of tracks.'])
+            PlotPretracking(data,b,tracks,feat_size,nm_per_pixel,filestub,'bandpass')            
+        otherwise
+            disp([char(9) 'No visual check. If desired use plotopt.'])              
     end
                 
     % Compute averaged centers to use as reference points for rest of analysis


### PR DESCRIPTION
Using a switch I added two different plot options ' simple', which only
shows raw data, and 'bandpassed' which shows both raw and bandpassed
data. These plot options are incorporated in a seperate function called
PlotPreTracking. The implementations of switches and iflopes code be
made shorter, however I think the way I wrote it down now makes it more
clear to read for human beings.
