### PR TITLE
fixed legends shift plot

### DIFF
--- a/mserror_calculator_4QM.m
+++ b/mserror_calculator_4QM.m
@@ -155,8 +155,10 @@ switch PlotOpt
         scatter(calibratedShift(trialCenters(:,6)==1,1), ...
                 trialCenters(trialCenters(:,6)==1,3),'k')
         box(ax1,'on')
-        legend('rejected','accepted','Location','northwest')
-        legend('boxoff')
+        if sum(trialCenters(:,6)) < size(trialCenters,1)
+            legend('rejected','accepted','Location','northwest')
+            legend('boxoff')
+        end
         ax2 = subplot(2,1,2);
         scatter(calibratedShift(trialCenters(:,6)==0,2), ...
                 trialCenters(trialCenters(:,6)==0,4),[],[0.7,0.7,0.7])
@@ -164,8 +166,10 @@ switch PlotOpt
         scatter(calibratedShift(trialCenters(:,6)==1,2), ...
                 trialCenters(trialCenters(:,6)==1,4),'k')
         box(ax2,'on')
-        legend('rejected','accepted','Location','northwest')
-        legend('boxoff')
+        if sum(trialCenters(:,6)) < size(trialCenters,1)
+            legend('rejected','accepted','Location','northwest')
+            legend('boxoff')
+        end
         xlabel(ax1,'\Deltax_{4QM} (pixels)')
         xlabel(ax2,'\Deltay_{4QM} (pixels)')
         ylabel(ax1,'\Deltax_{ref} (pixels)')

--- a/tracker_caller_4QM.m
+++ b/tracker_caller_4QM.m
@@ -170,7 +170,7 @@ disp([char(9) 'Find single particle calibration parameters.'])
                                                     p.NTests); 
                                         
 rmserror = sqrt((CalibParams(:,3) + CalibParams(:,6)));
-    
+
 %% Use single particle calibrations with 4QM to process real data
 disp([char(10) '4QM ... '])
 disp([char(9) 'Processing real data.'])
@@ -203,10 +203,10 @@ switch p.PlotOpt
         whitebg(fig3,[1,1,1])
         loglog(0:size(MSDs,1)-1,MSDs(:,1)-2*mean(rmserror)^2,'.','color','k')
         hold on
-        ylim([0.1,100])
+        ylim([1,max(MSDs(:,1))*10])
         title('Averaged MSD');
         xlabel('\tau (s)');
-        ylabel('corrected \langledR^{2}\rangle (m^{2})');
+        ylabel('corrected \langledR^{2}\rangle (nm^{2})');
         savefig([FileStub '_correctedmsd'])
 end
 


### PR DESCRIPTION
In the shift plot the legend did show rejected if there were only accepted particles. Now the legend is only shown if there are also rejected particles.
