### PR TITLE
Sign change center calculations

### DIFF
--- a/fake_data_maker.m
+++ b/fake_data_maker.m
@@ -15,7 +15,8 @@ function [] = fake_data_maker(NFrames,SigPtcle,stdStep,RelativeNoiseAmplitude,Ve
 % VARIABLES
 maxInt = 255;
 dt = 1;
-
+xbound = 512;
+ybound = 512;
 % FILENAMES
 stdStepStr = strrep(num2str(stdStep, '%.2f'), '.', '_');
 RelativeNoiseAmplitudeStr = strrep(num2str(RelativeNoiseAmplitude, '%.2f'), '.', '_');
@@ -28,15 +29,15 @@ mkdir(['data/' Experiment '/fov1'])
 % DATA CONSTRUCTION
 noise_amplitude = RelativeNoiseAmplitude*maxInt;
 
-x = 1:512;
-y = 1:512;
+x = 1:xbound;
+y = 1:ybound;
 
-[x y] = meshgrid(x,y);
+[x, y] = meshgrid(x,y);
 
-x0 = 51:47:512;
-y0 = 51:47:512;
+x0 = 51:47:xbound;
+y0 = 51:47:ybound;
 
-[x0 y0] = meshgrid(x0,y0);
+[x0, y0] = meshgrid(x0,y0);
 
 x0 = x0 + 15*(rand(size(x0))-0.5);
 y0 = y0 + 15*(rand(size(y0))-0.5);
@@ -51,6 +52,7 @@ for frame = 1:NFrames
     Tracks(1+(frame-1)*nptcles:(frame)*nptcles,3) = ones(1,nptcles)*frame;
     Tracks(1+(frame-1)*nptcles:(frame)*nptcles,4) = 1:nptcles;
     data = zeros(size(x));
+    
     
     for ptcle = 1:nptcles      
         data = data + exp(-((x-x1(ptcle)).^2 + (y-y1(ptcle)).^2)/(2*SigPtcle^2))*maxInt;       

--- a/mserror_calculator_4QM.m
+++ b/mserror_calculator_4QM.m
@@ -30,7 +30,7 @@ function [res,trialCenters] = mserror_calculator_4QM(Data,Tracks,FeatSize,DeltaF
 %   max_noise = max(abs(subdata(subdata(:)<(max(subdata(:))/ThreshFact))-mean_noise));
 %   SNR = mean(subdata(round(size(subdata,1)/2),round(size(subdata,2)/2),:))/mean_noise; %approximate signal to noise ratio
 %   temp_noise = 2*(rand([size(shifted_data)])-0.5)*std_noise/2 + mean_noise;
-
+%
 %   mean_shifted = mean(shifted_data(shifted_data(:)<(max(shifted_data(:))/threshfact))); % mean in shifted noise
 %   std_shifted = std(shifted_data(shifted_data(:)<(max(shifted_data(:))/threshfact))); % std in shifted noise
 %   normdata = (shifted_data - mean_shifted)/std_shifted;
@@ -77,7 +77,7 @@ for ParticleID = 1:max(Tracks(:,6))
     
     % Find the frame in which the particle is closest to its refCenter.
     metricDistance = sqrt((subTracks(:,1)-refCenters(ParticleID,1)).^2 ...
-        + (subTracks(:,2)-refCenters(ParticleID,2)).^2);
+                     + (subTracks(:,2)-refCenters(ParticleID,2)).^2);
     [~, refStep] = min(metricDistance);
     refsubData = subData(:,:,refStep);
     
@@ -101,14 +101,14 @@ for ParticleID = 1:max(Tracks(:,6))
     
     % Start calibration.
     [A,B,C,D] = FQM(shiftedData);
-    Centers = [(A+C-B-D)./(A+B+C+D) (A+B-C-D)./(A+B+C+D)];
+    Centers = [(-A-C+B+D)./(A+B+C+D) (-A-B+C+D)./(A+B+C+D)];
     refShift = [dxTrialShift dyTrialShift];
     
     % Find the p coefficients to calibrate shift detection by 4QM.
     [p1,fvalx] = fminsearch(@(p1) squeeze(mean((p1(1)*(Centers(:,1)+p1(2))-refShift(:,1)).^2,1)),...
-        [range(refShift(:,1))/range(Centers(:,1)),mean(refShift(:,1))]);
+                 [range(refShift(:,1))/range(Centers(:,1)),mean(refShift(:,1))]);
     [p2,fvaly] = fminsearch(@(p2) squeeze(mean((p2(1)*(Centers(:,2)+p2(2))-refShift(:,2)).^2,1)),...
-        [range(refShift(:,2))/range(Centers(:,2)),mean(refShift(:,2))]);
+                 [range(refShift(:,2))/range(Centers(:,2)),mean(refShift(:,2))]);
     errx = sqrt(fvalx);
     erry = sqrt(fvaly);
     res1 = [p1 errx p2 erry];
@@ -128,7 +128,7 @@ for ParticleID = 1:max(Tracks(:,6))
         
 end
 
-% Check if any Tracks were accepted and remove redundant rows in CalibParams.
+% Check if any Tracks were accepted.
 if sum(CalibParams(:,8)) == 0
     disp('Warning: No tracks below error threshhold!')
 end

--- a/tracker_caller_4QM.m
+++ b/tracker_caller_4QM.m
@@ -170,7 +170,7 @@ disp([char(9) 'Find single particle calibration parameters.'])
                                                     p.ErrorThresh, NParticles, ...
                                                     p.NTests); 
                                         
-rmserror = sqrt((CalibParams(:,3) + CalibParams(:,6)));
+rmserror = sqrt((CalibParams(CalibParams(:,8)==1,3) + CalibParams(CalibParams(:,8)==1,6)));
 
 %% Use single particle calibrations with 4QM to process real data
 disp([char(10) '4QM ... '])


### PR DESCRIPTION
The signs in the error calculation were wrong. This caused inversion of
all the QM tracks along the refcenter off the particle.
