### PR TITLE
Boxsize and Deltafit

### DIFF
--- a/SetAxisSubdata.m
+++ b/SetAxisSubdata.m
@@ -11,7 +11,7 @@ function Axis = SetAxisSubdata(CoarseCoord,FeatSize,DeltaFit)
 % OUTPUT:
 %   Axis: The pixel numbers of the pixels around the particle. 
 
-Offset = FeatSize-DeltaFit;       
+Offset = ceil(FeatSize/2)+DeltaFit;      
 if round(CoarseCoord) > CoarseCoord
     Axis = (round(CoarseCoord)-(Offset)): ...
            (round(CoarseCoord)+(Offset))-1;

--- a/fake_data_maker.m
+++ b/fake_data_maker.m
@@ -13,7 +13,7 @@ function [] = fake_data_maker(NFrames,SigPtcle,stdStep,RelativeNoiseAmplitude,Ve
 %   Version: A version number to avoid conflicts.
 
 % VARIABLES
-maxInt = 255;
+maxInt = 225;
 dt = 1;
 xbound = 512;
 ybound = 512;
@@ -40,7 +40,7 @@ y0 = 51:47:ybound;
 [x0, y0] = meshgrid(x0,y0);
 
 x0 = x0 + 15*(rand(size(x0))-0.5);
-y0 = y0 + 15*(rand(size(y0))-0.5);
+y0 = y0 + 15*(rand(size(y0))-0.5); 
 nptcles = length(x0(:));
 Tracks = zeros(nptcles*NFrames,4);
 
@@ -57,6 +57,7 @@ for frame = 1:NFrames
     for ptcle = 1:nptcles      
         data = data + exp(-((x-x1(ptcle)).^2 + (y-y1(ptcle)).^2)/(2*SigPtcle^2))*maxInt;       
     end
+     
     
     data = data + noise_amplitude*rand(size(data,1),size(data,2));
     data = data/(maxInt+noise_amplitude)*maxInt;

--- a/mserror_calculator_4QM.m
+++ b/mserror_calculator_4QM.m
@@ -46,8 +46,8 @@ function [res,trialCenters] = mserror_calculator_4QM(Data,Tracks,FeatSize,DeltaF
 
 
 %% Setup pixel grid for subdata frames.
-xGrid = 1:(2*(FeatSize-DeltaFit));
-yGrid = 1:(2*(FeatSize-DeltaFit));
+xGrid = 1:(2*(ceil(FeatSize/2)+DeltaFit));
+yGrid = 1:(2*(ceil(FeatSize/2)+DeltaFit));
 [xGrid, yGrid] = meshgrid(xGrid,yGrid);
 
 % Allocate space for CalibParams and Centers
@@ -81,7 +81,7 @@ for ParticleID = 1:max(Tracks(:,6))
     refsubData = subData(:,:,refStep);
     
     % Determine the trial shifts of the refFrame for 4QM calibration.
-    dxTrialShift = StepAmplitude*(randn(NTests,1));
+    dxTrialShift = StepAmplitude*(randn(NTests,1)); 
     dyTrialShift = StepAmplitude*(randn(NTests,1));
     
     % Create the trial data by shifting refsubData by TrialShift.
@@ -108,16 +108,17 @@ for ParticleID = 1:max(Tracks(:,6))
     refShift = [dxTrialShift dyTrialShift];
     
     % Find the p coefficients to calibrate shift detection by 4QM.
-    options = optimoptions(@lsqcurvefit, 'Display','none');
+    options = optimoptions(@lsqcurvefit,'Display','none');
     [p1,fvalx] = lsqcurvefit(@(p1,xdata) (p1(1)*xdata+p1(2)), ...
                  [range(refShift(:,1))/range(Centers(:,1)),mean(refShift(:,1))] ...
                  ,Centers(:,1),refShift(:,1),[],[],options);  
     [p2,fvaly] = lsqcurvefit(@(p2,xdata) (p2(1)*xdata+p2(2)), ...
                  [range(refShift(:,2))/range(Centers(:,2)),mean(refShift(:,2))] ...
                  ,Centers(:,2),refShift(:,2),[],[],options);
-    errx = sqrt(fvalx);
-    erry = sqrt(fvaly);
-    res1 = [p1 errx p2 erry];
+
+    errx = sqrt(fvalx/size(Centers,1));
+    erry = sqrt(fvaly/size(Centers,1));
+    res1 = [p1 errx p2 erry]; 
  
     trialCenters((ParticleID-1)*NTests+1:(ParticleID)*NTests,1:2) = Centers;
     trialCenters((ParticleID-1)*NTests+1:(ParticleID)*NTests,3:4) = refShift;


### PR DESCRIPTION
For accuracy the boxsize of the 4QM method should be bigger. To make it
easier to adjust this, we now define the standard box around 4QM to be
the feature size. DeltaFit can be given a positive value to increase
edge around the particle. Setting it to 9 would increase all sides with
9 pixels.
